### PR TITLE
chore: dont use service worker if node env is dev

### DIFF
--- a/sapper/rollup.config.js
+++ b/sapper/rollup.config.js
@@ -112,7 +112,7 @@ export default {
     onwarn,
   },
 
-  serviceworker: {
+  serviceworker: !dev && {
     input: config.serviceworker.input(),
     output: config.serviceworker.output(),
     plugins: [


### PR DESCRIPTION
Dont know why but the service worker is starting to act up, somehow blocking the rest of the application, making it impossible to develop (chrome). So lets just not use that if node env === dev